### PR TITLE
:bookmark: bump version 0.1.0 -> 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 ## [Unreleased]
 
+## [0.1.1]
+
 ### Changed
 
 - Bumped the minimum version of django-bird to v0.16.2.
@@ -33,5 +35,6 @@ and this project attempts to adhere to [Semantic Versioning](https://semver.org/
 
 - Josh Thomas <josh@joshthomas.dev> (maintainer)
 
-[unreleased]: https://github.com/joshuadavidthomas/django-bird-autoconf/compare/v0.1.0...HEAD
+[unreleased]: https://github.com/joshuadavidthomas/django-bird-autoconf/compare/v0.1.1...HEAD
 [0.1.0]: https://github.com/joshuadavidthomas/django-bird-autoconf/releases/tag/v0.1.0
+[0.1.1]: https://github.com/joshuadavidthomas/django-bird-autoconf/releases/tag/v0.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ license = {file = "LICENSE"}
 name = "django-bird-autoconf"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.1.0"
+version = "0.1.1"
 
 [project.entry-points.django-bird]
 autoconf = "django_bird_autoconf.plugin"
@@ -63,7 +63,7 @@ reportUnusedCallResult = false
 [tool.bumpver]
 commit = true
 commit_message = ":bookmark: bump version {old_version} -> {new_version}"
-current_version = "0.1.0"
+current_version = "0.1.1"
 push = false  # set to false for CI
 tag = false
 version_pattern = "MAJOR.MINOR.PATCH[PYTAGNUM]"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ from django_bird_autoconf import __version__
 
 
 def test_version():
-    assert __version__ == "0.1.0"
+    assert __version__ == "0.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -181,7 +181,7 @@ wheels = [
 
 [[package]]
 name = "django-bird-autoconf"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "django-bird" },


### PR DESCRIPTION
- `83f1334`: adjust test settings and initial test (#3)
- `2f8b6ee`: bump minimum version of django-bird (#4)
- `438bfb5`: change to using `pre_ready` hook from django-bird (#5)